### PR TITLE
Task 1: Change Requests

### DIFF
--- a/db/models/Ticket.ts
+++ b/db/models/Ticket.ts
@@ -22,7 +22,7 @@ export enum TicketType {
 
 export enum TicketCategory {
   accounting = 'accounting',
-  corporate = 'registrationAddressChange',
+  corporate = 'corporate',
   management = 'management',
 }
 

--- a/db/models/User.ts
+++ b/db/models/User.ts
@@ -12,6 +12,7 @@ import { Company } from './Company';
 export enum UserRole {
   accountant = 'accountant',
   corporateSecretary = 'corporateSecretary',
+  director = 'director',
 }
 
 @Table({ tableName: 'users' })


### PR DESCRIPTION
Task 1 Summary

  Problem:
  - Duplicate Prevention: System allowed multiple registrationAddressChange tickets per company
  - Missing Director Role: No Director role existed in system
  - No Fallback Logic: Only Corporate Secretary could handle registrationAddressChange tickets
  - Critical Bug: TicketCategory.corporate had wrong enum value 'registrationAddressChange' instead of 'corporate'

  Solutions Implemented:
  - Duplication Check: Added query to prevent duplicate active registrationAddressChange tickets per company
  - Director Role: Added director to UserRole enum
  - Fallback Hierarchy: Corporate Secretary → Director → Error logic implemented
  - Bug Fix: Corrected enum value from 'registrationAddressChange' to 'corporate'
  - Error Handling: Clear, specific error messages for all scenarios
  - Comprehensive Testing: 4 new test cases covering all edge cases

  Key AI Contributions:
  - Test Coverage: Designed comprehensive test scenarios for all edge cases
  - Error Handling: Created specific, actionable error messages
  - Code Quality: Fixed syntax errors and lint issues while maintaining existing patterns
  - Bug Detection: Identified and fixed critical enum value bug that would cause runtime issues